### PR TITLE
Update io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1082,7 +1082,7 @@
       "common": {
         "role": "media.seek",
         "name": "Controlling playback seek",
-        "type": "number",
+        "type": "string",
         "unit": "%",
         "min": 0,
         "max": 100,
@@ -1294,7 +1294,7 @@
       "type": "state",
       "common": {
         "name": "elapsed",
-        "type": "number",
+        "type": "string",
         "role": "media.elapsed"
       },
       "native": {}


### PR DESCRIPTION
This fixes minor Bug where wrong Variable type was used which creates warnings

mpd.0 | 2023-01-08 21:39:55.606 | info | State value to set for "mpd.0.elapsed" has to be type "number" but received type "string"
mpd.0 | 2023-01-08 21:39:54.599 | info | State value to set for "mpd.0.seek" has to be type "number" but received type "string"